### PR TITLE
feat: add missing business logic for renewal process

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ function App() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/renewal" element={<SignupPage type="renewal" />} />
         <Route path="/payment-option" element={<RequireMemberData><PaymentOptionPage /></RequireMemberData>} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/manage-payments" element={<ManagePaymentsPage />} />
@@ -24,6 +25,7 @@ function App() {
         <Route path="/account-creation" element={<AccountCreationPage />} />
         <Route path="/home" element={<Home />} />
         <Route path="/terms-policy" element={<TermsPolicyPage />} />
+        <Route path="*" element={<div>404 Not Found</div>} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/pages/SignupPage.jsx
+++ b/frontend/src/components/pages/SignupPage.jsx
@@ -2,11 +2,11 @@ import { ThemeProvider } from "@/components/theme-provider";
 import WaveBackground from "@/components/wave-background";
 import { SignupForm } from "@/components/signup-form";
 
-export default function SignupPage() {
+export default function SignupPage({ type }) {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <WaveBackground />
-      <SignupForm />
+      <SignupForm type={type} />
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/signup-form.jsx
+++ b/frontend/src/components/signup-form.jsx
@@ -7,14 +7,16 @@
   import { useSignupViewModel } from "@/integration/signup-view-model";
 
 
-  export function SignupForm({ className, ...props }) {
+  export function SignupForm({ type, className, ...props }) {
     const {
         form,
         loading,
         responseMessage,
         handleChange,
         handleSubmit
-      } = useSignupViewModel();
+      } = useSignupViewModel(type);
+
+      const header = type === "renewal" ? "Renew Membership" : "Create Account";
       
     return (
       <div className="relative flex min-h-screen flex-col items-center justify-center p-6 md:p-10 overflow-hidden z-10">
@@ -25,9 +27,11 @@
                 <form onSubmit={handleSubmit} className="p-6 md:p-8">
                   <div className="flex flex-col gap-6">
                     <div className="flex flex-col items-center text-center">
-                      <h1 className="text-2xl font-bold">Create Account</h1>
+                      <h1 className="text-2xl font-bold">{header}</h1>
                       <p className="text-muted-foreground text-balance">
-                        Sign up for your ICON account
+                        {type === "renewal"
+                          ? "Renew your ICON Membership"
+                          : "Sign up for your ICON Membership"}
                       </p>
                     </div>
 

--- a/frontend/src/integration/signup-view-model.jsx
+++ b/frontend/src/integration/signup-view-model.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import axios, {AxiosError} from "axios";
 import {useNavigate} from "react-router-dom";
 
-export function useSignupViewModel() {
+export function useSignupViewModel(type) {
   const [form, setForm] = useState({
     name: "",
     idNumber: "",
@@ -26,12 +26,24 @@ export function useSignupViewModel() {
     setLoading(true);
     setResponseMessage("");
 
+
     try {
-      const response = await axios.post("http://localhost:3000/api/v2/members", form);
-      setResponseMessage("Account created successfully!");
-      console.log("API response:", response.data);
-      localStorage.setItem("memberData", JSON.stringify(response.data));
-      navigate('/payment-option');
+      if(type === "renewal"){
+        console.log("Renewal form submitted:", form.id);
+        const renewalForm = form;
+        delete renewalForm.idNumber;
+        const response = await axios.put(`http://localhost:3000/api/v2/members/${form.id}`, renewalForm);
+        setResponseMessage("Account created successfully!");
+        console.log("API response:", response.data);
+        localStorage.setItem("memberData", JSON.stringify(response.data));
+        navigate('/payment-option');
+      }else{
+        const response = await axios.post("http://localhost:3000/api/v2/members", form);
+        setResponseMessage("Account created successfully!");
+        console.log("API response:", response.data);
+        localStorage.setItem("memberData", JSON.stringify(response.data));
+        navigate('/payment-option');
+      }
     } catch (error) {
       console.log(error instanceof AxiosError)
       if (error instanceof AxiosError) {


### PR DESCRIPTION
This pull request adds support for membership renewal to the signup flow in the frontend application. The changes introduce a new `/renewal` route, update the signup form and its view model to handle renewal-specific logic, and improve user feedback and error handling. Additionally, a catch-all route for 404 errors is added.

**Membership Renewal Feature:**

* Added a new `/renewal` route in `App.jsx` that renders the `SignupPage` with a `type="renewal"` prop, allowing users to renew their membership.
* Updated `SignupPage` and `SignupForm` components to accept a `type` prop, enabling conditional rendering of headers and descriptions for renewal versus account creation. [[1]](diffhunk://#diff-dc36257716158d18db224db61a1a9b524b64bcdc20e1020046d38dc57af936baL5-R9) [[2]](diffhunk://#diff-2c975de1b7b96b8e8d5658ef411fb72c3077b496143a75843f8bb19ba8e67a3fL10-R19) [[3]](diffhunk://#diff-2c975de1b7b96b8e8d5658ef411fb72c3077b496143a75843f8bb19ba8e67a3fL28-R34)
* Modified `useSignupViewModel` to handle renewal submissions: if the form is for renewal, it sends a `PUT` request to update member data instead of a `POST` for new accounts, and omits the `idNumber` field. [[1]](diffhunk://#diff-77a32fbca609e8f1c01e8553c56fceb39002b7b6f839b02996304c0cf9ca766fL5-R5) [[2]](diffhunk://#diff-77a32fbca609e8f1c01e8553c56fceb39002b7b6f839b02996304c0cf9ca766fR29-R46)

**Routing and Error Handling:**

* Added a catch-all route (`*`) in `App.jsx` to display a "404 Not Found" message for unrecognized URLs.